### PR TITLE
(#35, #37) Update url for redirecting to CT.Gov.

### DIFF
--- a/LegacyCDE.Web/Web.config
+++ b/LegacyCDE.Web/Web.config
@@ -19,7 +19,8 @@
   
   <appSettings>
     <!-- Quick and dirty CTS settings. -->
-    <add key="CTS_DetailedViewPagePrettyUrl" value="https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/v" />
+    <add key="CTS_DetailedViewPagePrettyUrlFormat" value="https://www.cancer.gov/research/participate/clinical-trials-search/v?id={0}&amp;r=1" />
+    <add key="CTGov_RedirectionURLFormat" value="https://clinicaltrials.gov/study/{0}" />
     <!-- /Quick and dirty CTS settings. -->
   </appSettings>
 


### PR DESCRIPTION
- Moves the URL to the web.config.
- Add default values for Redirect and Search url properties.

Closes #35 
Closes #37 
